### PR TITLE
Fix: Ensure modal opens consistently on repeated card clicks

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -154,34 +154,32 @@ if (galleryDisplay) {
         }
       }
 
-      // Add event listener for when the model in the card has loaded
-      if (cardModelViewer) {
-        cardModelViewer.addEventListener('load', () => {
-          console.log(`Model ${modelUrl} loaded in card, preparing and opening modal.`);
-
-          // Now that the card model has loaded, set up and show the modal
-          if (modalViewer) {
-            modalViewer.setAttribute('src', modelUrl);
-            modalViewer.setAttribute('alt', window.currentModelTitle);
-          }
-
-          if (overlay) {
-            overlay.style.display = 'flex';
-            document.body.style.overflow = 'hidden';
-          }
-        }, { once: true }); // { once: true } ensures this listener only fires once for this specific load
-      } else {
-        // Fallback if cardModelViewer somehow isn't found, open modal immediately (old behavior)
-        // This case should ideally not be hit if HTML structure is correct
-        console.warn('Card model viewer not found, opening modal immediately.');
+      // Function to open the modal (to avoid code duplication)
+      const openModalWithModel = () => {
+        console.log(`Model ${modelUrl} is ready or loaded in card, preparing and opening modal.`);
         if (modalViewer) {
-            modalViewer.setAttribute('src', modelUrl);
-            modalViewer.setAttribute('alt', window.currentModelTitle);
+          modalViewer.setAttribute('src', modelUrl);
+          modalViewer.setAttribute('alt', window.currentModelTitle);
         }
         if (overlay) {
-            overlay.style.display = 'flex';
-            document.body.style.overflow = 'hidden';
+          overlay.style.display = 'flex';
+          document.body.style.overflow = 'hidden';
         }
+      };
+
+      // Check if the card's model-viewer is already loaded with the correct src
+      if (cardModelViewer && cardModelViewer.loaded && cardModelViewer.src === modelUrl) {
+        // If already loaded and src is correct, open modal immediately
+        openModalWithModel();
+      } else if (cardModelViewer) {
+        // Otherwise, if src is different or not loaded, ensure src is set and wait for it to load
+        // The src attribute might have already been set just above this block if it was new
+        // This event listener will handle the case where it's still loading
+        cardModelViewer.addEventListener('load', openModalWithModel, { once: true });
+      } else {
+        // Fallback if cardModelViewer somehow isn't found (shouldn't happen)
+        console.warn('Card model viewer not found, opening modal immediately (fallback).');
+        openModalWithModel();
       }
     }
   });


### PR DESCRIPTION
- I modified the gallery card click handler in `js/app.js`.
- If a model is already loaded in the card, the modal now opens immediately.
- If the model is not yet loaded, the modal still waits for the card's model to load before opening.
- This resolves an issue where the modal would not reopen for the same card after being closed, due to the previous use of a one-time 'load' event listener without checking the loaded state.