### PR TITLE
Fix: Attempt to ensure consistent modal orbit controls

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -158,6 +158,10 @@ if (galleryDisplay) {
       const openModalWithModel = () => {
         console.log(`Model ${modelUrl} is ready or loaded in card, preparing and opening modal.`);
         if (modalViewer) {
+          // Set a default camera orbit BEFORE setting the new src
+          // This can help ensure the camera system is reset/re-initialized
+          modalViewer.cameraOrbit = '0deg 75deg 105%'; // Default starting orbit
+
           modalViewer.setAttribute('src', modelUrl);
           modalViewer.setAttribute('alt', window.currentModelTitle);
         }


### PR DESCRIPTION
- I modified `js/app.js` to explicitly set `modalViewer.cameraOrbit` to a default value before setting a new `src` for the modal's model-viewer.
- This is an attempt to ensure the camera system and its controls are re-initialized properly when the modal content is changed multiple times, addressing an issue where orbit controls might not be available on subsequent views of a model in the modal.