### PR TITLE
I've refactored the code to simplify the server logic, and it now exc…

### DIFF
--- a/js/piping-utils.js
+++ b/js/piping-utils.js
@@ -1,25 +1,16 @@
 // js/piping-utils.js
 // Provides shared constants and functions for piping server management.
+// Simplified to use only ppng.io.
 
 // ===== PIPING SERVER CONFIGURATION =====
-const PIPING_SERVERS = [
-  'https://ppng.io/',
-  'https://piping.onrender.com/',
-  'https://piping-server.herokuapp.com/',
-  'https://pipes.sh/'
-];
-
-// Global server state managed by these utils
-// These are intended to be modified by findWorkingPipingServer and used by URL builders.
-var PipingUtils_CURRENT_DOMAIN = PIPING_SERVERS[0]; // Using var for wider compatibility if not module
-var PipingUtils_TESTED_SERVERS = new Map();
+const PipingUtils_CURRENT_DOMAIN = 'https://ppng.io/';
 
 // ===== UTILITY FUNCTIONS =====
 function PipingUtils_getRandomInt(max) {
   return Math.floor(Math.random() * Math.floor(max));
 }
 
-// URL builders - use the PipingUtils_CURRENT_DOMAIN
+// URL builders - use the hardcoded PipingUtils_CURRENT_DOMAIN
 function PipingUtils_getSessionUrl(pipeId, sessionId) {
   return `${PipingUtils_CURRENT_DOMAIN}${pipeId}-${sessionId}`;
 }
@@ -49,64 +40,7 @@ function PipingUtils_getMobileOperatingSystem() {
   return 'unknown';
 }
 
-// ===== SERVER TESTING AND SELECTION =====
-async function PipingUtils_testPipingServer(serverUrl) {
-  const testId = PipingUtils_getRandomInt(1e+10);
-  const testPath = `test-${testId}`;
-  const testUrl = `${serverUrl}${testPath}`;
-
-  try {
-    // console.log(`🔍 [PipingUtils] Testing server: ${serverUrl}`);
-    const headResponse = await fetch(testUrl, { method: 'HEAD', mode: 'cors', signal: AbortSignal.timeout(3000) });
-    if (headResponse.status < 500) {
-      const postResponse = await fetch(testUrl, {
-        method: 'POST', body: JSON.stringify({test: 'connectivity'}), mode: 'cors',
-        headers: { 'Content-Type': 'application/json' }, signal: AbortSignal.timeout(3000)
-      });
-      if (postResponse.ok || postResponse.status === 404) {
-        // console.log(`✅ [PipingUtils] Server working: ${serverUrl}`);
-        return true;
-      }
-    }
-    // console.log(`⚠️ [PipingUtils] Server test failed (HEAD or POST): ${serverUrl}`);
-    return false;
-  } catch (error) {
-    // console.log(`❌ [PipingUtils] Server test exception: ${serverUrl} - ${error.message}`);
-    return false;
-  }
-}
-
-async function PipingUtils_findWorkingPipingServer() {
-  // console.log('[PipingUtils] Finding working piping server...');
-  for (const [server, result] of PipingUtils_TESTED_SERVERS.entries()) {
-    if (result.working && (Date.now() - result.timestamp) < 300000) { // 5 min cache
-      // console.log(`🎯 [PipingUtils] Using cached working server: ${server}`);
-      PipingUtils_CURRENT_DOMAIN = server;
-      return server;
-    }
-  }
-
-  for (const server of PIPING_SERVERS) { // Uses const PIPING_SERVERS from this file
-    const isWorking = await PipingUtils_testPipingServer(server);
-    PipingUtils_TESTED_SERVERS.set(server, { working: isWorking, timestamp: Date.now() });
-    if (isWorking) {
-      PipingUtils_CURRENT_DOMAIN = server;
-      console.log(`🌟 [PipingUtils] Selected working server: ${server}`);
-      return server;
-    }
-  }
-
-  console.error('❌ [PipingUtils] No working piping servers found.');
-  PipingUtils_CURRENT_DOMAIN = PIPING_SERVERS[0]; // Fallback
-  console.warn(`⚠️ [PipingUtils] Defaulting to first server: ${PipingUtils_CURRENT_DOMAIN} as no server passed tests.`);
-  return null; // Indicates no server *passed tests*, but CURRENT_DOMAIN is set to a default.
-}
-
 // Basic fetch POST and GET utilities.
-// The more complex retry logic and ErrorHandler integration will remain in the consuming scripts (qr-deploy.js, mobile_view.js)
-// as they are more tightly coupled with the specific error handling and UI update needs of those contexts.
-// These are simpler helpers if needed, or can be omitted if the consuming scripts always use their own.
-
 async function PipingUtils_post(content, url) {
   const response = await fetch(url, {
     method: 'POST', body: content, mode: 'cors',
@@ -130,10 +64,8 @@ async function PipingUtils_getWithTimeout(url, timeout = 30000) {
 
 
 // To make these available globally IF this script is loaded:
-// (This is a simple approach; modules would be better for larger projects)
 window.PipingUtils = {
-  PIPING_SERVERS, // Expose the list
-  // Expose functions, they will use the internal PipingUtils_CURRENT_DOMAIN and PipingUtils_TESTED_SERVERS
+  // Expose functions
   getRandomInt: PipingUtils_getRandomInt,
   getSessionUrl: PipingUtils_getSessionUrl,
   getPingUrl: PipingUtils_getPingUrl,
@@ -141,10 +73,9 @@ window.PipingUtils = {
   gltfToSession: PipingUtils_gltfToSession,
   envToSession: PipingUtils_envToSession,
   getMobileOperatingSystem: PipingUtils_getMobileOperatingSystem,
-  findWorkingPipingServer: PipingUtils_findWorkingPipingServer, // This sets the internal domain and returns it
-  // Expose a getter for the current domain determined by findWorkingPipingServer
+  // Expose a getter for the current domain
   getCurrentDomain: () => PipingUtils_CURRENT_DOMAIN,
-  // Basic fetch helpers (optional, consuming scripts might have their own more complex ones)
+  // Basic fetch helpers
   post: PipingUtils_post,
   getWithTimeout: PipingUtils_getWithTimeout
 };

--- a/js/qr-deploy.js
+++ b/js/qr-deploy.js
@@ -198,19 +198,14 @@ window.DeploymentErrorHandler = ErrorHandler;
 // and retry logic remain here as they are specific to this deployment context.
 // Simpler base versions are in PipingUtils if ever needed.
 
-// Enhanced POST function with better error handling and retry logic
-async function post(content, url) { // This 'post' is specific to qr-deploy's needs
-  let currentPipingDomain = PipingUtils.getCurrentDomain(); // Get domain from util
-  let attemptUrl = url;
+// The complex post and getWithTimeout functions are now simplified as there's no server fallback logic.
+// We can use the simpler versions from PipingUtils directly or keep these local ones if we
+// want to maintain the tight integration with ErrorHandler. Let's keep them local for now
+// but remove the retry/fallback logic.
 
-  // If the URL doesn't already have a domain, prepend the current piping domain
-  // This logic might need adjustment if `url` can sometimes be absolute.
-  // Assuming `url` is often a path that needs the domain.
-  // For now, the URL construction helpers from PipingUtils should be used to generate full URLs.
-  // This means `url` passed to this post function should already be a full URL.
-
+async function post(content, url) {
   try {
-    const response = await fetch(attemptUrl, {
+    const response = await fetch(url, {
       method: 'POST',
       body: content,
       mode: 'cors',
@@ -221,115 +216,38 @@ async function post(content, url) { // This 'post' is specific to qr-deploy's ne
     });
     
     if (response.ok) {
-      console.log('✅ POST Success:', attemptUrl);
+      console.log('✅ POST Success:', url);
       return response;
     } else {
-      throw new Error(`HTTP ${response.status}: ${response.statusText} from URL ${attemptUrl}`);
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }
   } catch (error) {
-    console.warn(`⚠️ POST failed with ${currentPipingDomain}: ${attemptUrl}`, error);
-    // Try to find a new working server
-    const newWorkingServer = await PipingUtils.findWorkingPipingServer();
-    if (newWorkingServer && newWorkingServer !== currentPipingDomain) {
-      console.log(`🔄 Retrying POST with new server: ${newWorkingServer}`);
-      // Reconstruct the URL with the new domain if the original URL was based on the old domain
-      // This assumes the URL structure allows simple replacement.
-      // It's safer if URLs are always constructed fresh using PipingUtils.getXUrl() functions.
-      // For this refactor, let's assume `url` is the original full path and we reconstruct it.
-      // This part is tricky if `url` was not originally formed with `currentPipingDomain`.
-      // The URL helpers (getSessionUrl etc.) should be used to get the correct new URL.
-      // This retry logic needs to be robust.
-      // For now, we'll assume the URL path part needs to be extracted and prepended with new server.
-      // This is a simplification. A better way is to re-generate the URL using the new domain.
-      let originalPath = "";
-      try {
-        originalPath = new URL(url).pathname + new URL(url).search + new URL(url).hash;
-      } catch(e) { /* if url is not absolute */ originalPath = url; }
-      
-      const newAttemptUrl = newWorkingServer + originalPath.substring(1); // Assuming path starts with / after domain
-
-      try {
-        const retryResponse = await fetch(newAttemptUrl, {
-          method: 'POST',
-          body: content,
-          mode: 'cors',
-          headers: { 'Content-Type': typeof content === 'string' ? 'application/json' : 'application/octet-stream'},
-          signal: AbortSignal.timeout(30000)
-        });
-        if (retryResponse.ok) {
-          console.log('✅ POST Success with alternative server:', newAttemptUrl);
-          return retryResponse;
-        } else {
-           throw new Error(`HTTP ${retryResponse.status}: ${retryResponse.statusText} from URL ${newAttemptUrl} (retry)`);
-        }
-      } catch (retryError) {
-        console.error('❌ POST Retry also failed:', retryError);
-        if (ErrorHandler && typeof ErrorHandler.showCSPError === 'function' && retryError.name === 'TypeError' && retryError.message.includes('Failed to fetch')) {
-            ErrorHandler.showCSPError('Network request blocked or server unavailable on retry.');
-        }
-        throw retryError; // Throw the error from the retry attempt
-      }
-    } else if (!newWorkingServer) {
-        console.error('❌ No alternative working server found for POST.');
+    console.error(`❌ POST Failed for ${url}:`, error);
+    if (ErrorHandler && error.name === 'TypeError' && error.message.includes('Failed to fetch')) {
+      ErrorHandler.showCSPError('Network request blocked or server unavailable.');
     }
-    // If newWorkingServer is the same as currentPipingDomain, or no new server, throw original error
-    if (ErrorHandler && typeof ErrorHandler.showCSPError === 'function' && error.name === 'TypeError' && error.message.includes('Failed to fetch')) {
-        ErrorHandler.showCSPError('Network request blocked or server unavailable.');
-    }
-    throw error; // Throw the original error
+    throw error;
   }
 }
 
-// Enhanced GET function with retry logic
-async function getWithTimeout(url, timeout = 30000) { // This 'getWithTimeout' is specific to qr-deploy's needs
-  let currentPipingDomain = PipingUtils.getCurrentDomain();
-  let attemptUrl = url;
-
+async function getWithTimeout(url, timeout = 30000) {
   try {
     const controller = new AbortController();
     const id = setTimeout(() => controller.abort(), timeout);
-    const response = await fetch(attemptUrl, { method: 'GET', signal: controller.signal, mode: 'cors' });
+    const response = await fetch(url, { method: 'GET', signal: controller.signal, mode: 'cors' });
     clearTimeout(id);
     
-    if (response.ok || response.status === 404) { // 404 is expected for piping GETs
+    if (response.ok || response.status === 404) {
       return response;
     } else {
-      throw new Error(`HTTP ${response.status}: ${response.statusText} from URL ${attemptUrl}`);
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }
   } catch (error) {
-    console.warn(`⚠️ GET failed or timed out with ${currentPipingDomain}: ${attemptUrl}`, error);
-    if (error.name === 'AbortError') { // Don't retry client-side timeouts for GET
-        throw error;
+    console.error(`❌ GET Failed or Timed Out for ${url}:`, error);
+    if (ErrorHandler && error.name === 'TypeError' && error.message.includes('Failed to fetch')) {
+      ErrorHandler.showCSPError('Network request blocked or server unavailable.');
     }
-
-    const newWorkingServer = await PipingUtils.findWorkingPipingServer();
-    if (newWorkingServer && newWorkingServer !== currentPipingDomain) {
-      console.log(`🔄 Retrying GET with new server: ${newWorkingServer}`);
-      let originalPath = "";
-      try {
-        originalPath = new URL(url).pathname + new URL(url).search + new URL(url).hash;
-      } catch(e) { originalPath = url; }
-      const newAttemptUrl = newWorkingServer + originalPath.substring(1);
-
-      try {
-        const controller = new AbortController();
-        const id = setTimeout(() => controller.abort(), timeout);
-        const retryResponse = await fetch(newAttemptUrl, { method: 'GET', signal: controller.signal, mode: 'cors'});
-        clearTimeout(id);
-        if (retryResponse.ok || retryResponse.status === 404) {
-          console.log('✅ GET Success with alternative server:', newAttemptUrl);
-          return retryResponse;
-        } else {
-          throw new Error(`HTTP ${retryResponse.status}: ${retryResponse.statusText} from URL ${newAttemptUrl} (retry)`);
-        }
-      } catch (retryError) {
-        console.error('❌ GET Retry also failed:', retryError);
-        throw retryError;
-      }
-    } else if (!newWorkingServer) {
-        console.error('❌ No alternative working server found for GET.');
-    }
-    throw error; // Throw original error if no retry or retry failed
+    throw error;
   }
 }
 
@@ -373,33 +291,17 @@ class GoogleMobileDeployment {
   }
 
   async initializeServer() {
+    // This method is now much simpler as we are not testing servers.
     console.log('🚀 Initializing piping server connection...');
-    this.updateStatus('Finding working piping server...', 'info');
+    const currentPipingDomain = PipingUtils.getCurrentDomain();
+    this.updateStatus(`Using server: ${currentPipingDomain}`, 'success');
+    console.log(`✅ Using hardcoded server: ${currentPipingDomain}`);
     
-    const workingServer = await findWorkingPipingServer();
-    // PipingUtils.findWorkingPipingServer() now sets PipingUtils_CURRENT_DOMAIN internally
-    // and also returns the server. We can use PipingUtils.getCurrentDomain() or the returned value.
+    // Set ping URL with the fixed server
+    this.mobilePingUrl = PipingUtils.getPingUrl(this.pipeId);
     
-    if (workingServer) { // newWorkingServer will be null if no server passed tests, but a default is set in PipingUtils
-      const currentPipingDomain = PipingUtils.getCurrentDomain(); // Get the domain set by findWorkingPipingServer
-      this.updateStatus(`Connected to: ${currentPipingDomain}`, 'success');
-      console.log(`✅ Successfully connected to: ${currentPipingDomain}`);
-      
-      // Update ping URL with working server
-      this.mobilePingUrl = PipingUtils.getPingUrl(this.pipeId); // Use util
-      
-      // Initialize event listeners after server is ready
-      this.init();
-    } else {
-      this.updateStatus('❌ No working piping servers available. Please try again later.', 'error');
-      console.error('❌ Failed to find working piping server');
-      
-      // Disable deploy button
-      if (this.elements.modalDeployBtn) {
-        this.elements.modalDeployBtn.disabled = true;
-        this.elements.modalDeployBtn.textContent = 'Servers Unavailable';
-      }
-    }
+    // Proceed with initialization
+    this.init();
   }
 
   initializeElements() {
@@ -612,18 +514,10 @@ class GoogleMobileDeployment {
       }
     } catch (error) {
       console.log('Ping error:', error);
-      
-      // If it's a server error, try to find working server
-      if (error.message.includes('Failed to fetch') || error.message.includes('HTTP 5')) {
-        this.updateStatus('Server connection lost, finding alternative...', 'error');
-        const newServer = await findWorkingPipingServer();
-        if (newServer) {
-          this.mobilePingUrl = getPingUrl(this.pipeId);
-          this.updateStatus(`Reconnected to: ${newServer}`, 'success');
-        }
-      }
-      
-      await this.delay(1000);
+      // Since there's no server fallback, we just log the error and wait before trying again.
+      // We could add a status update here to inform the user of a connection issue.
+      this.updateStatus('Connection issue. Retrying...', 'error');
+      await this.delay(5000); // Wait longer if there's an error
     }
     
     this.pingLoop();

--- a/view/mobile_view.js
+++ b/view/mobile_view.js
@@ -65,6 +65,7 @@ class GoogleMobileView {
     }
     
     if (!this.pipeId) {
+      // This is now handled by the DOMContentLoaded listener, but keeping a check here is safe.
       console.error('❌ No pipe ID found in URL');
       this.showToast('Error: No connection ID found in URL. Please scan QR code again.');
       return;
@@ -75,20 +76,11 @@ class GoogleMobileView {
       this.overlay.style.display = 'flex';
     }
 
-    // Find working server
-    this.showToast('Connecting to server...');
-    // Use PipingUtils.findWorkingPipingServer() which sets PipingUtils_CURRENT_DOMAIN
-    const foundServer = await PipingUtils.findWorkingPipingServer();
-    const currentPipingDomain = PipingUtils.getCurrentDomain(); // Get the domain chosen by the util
+    // Server is now fixed, no need to find/test.
+    const currentPipingDomain = PipingUtils.getCurrentDomain();
+    this.showToast(`Connecting via: ${currentPipingDomain.replace('https://', '').replace('/', '')}`);
 
-    if (!foundServer) { // findWorkingPipingServer returns null if no *tested* server worked, but sets a default
-      this.showToast(`⚠️ No servers passed tests. Using default: ${currentPipingDomain.replace('https://', '').replace('/', '')}`);
-      // Proceeding with default server
-    } else {
-      this.showToast(`Connected to: ${currentPipingDomain.replace('https://', '').replace('/', '')}`);
-    }
-
-    // Set URLs with working/default server from PipingUtils
+    // Set URLs with fixed server from PipingUtils
     this.mobilePingUrl = PipingUtils.getPingUrl(this.pipeId);
     this.sessionUrl = PipingUtils.getSessionUrl(this.pipeId, this.sessionId);
     
@@ -272,10 +264,9 @@ class GoogleMobileView {
     console.log('📢 Toast:', message);
   }
 
-  // Fetch loop with retry logic
+  // Fetch loop (simplified, no server fallback logic)
   async fetchLoop() {
     try {
-      // Use PipingUtils.getWithTimeout or a local version if more complex error handling is needed
       const response = await PipingUtils.getWithTimeout(this.sessionUrl);
       
       if (response.ok) {
@@ -290,33 +281,13 @@ class GoogleMobileView {
         return true;
       } else {
         console.error('❌ Error fetching update from mobile view:', response.status, response.statusText, this.sessionUrl);
-        // Potentially try to find a new server if response indicates server failure (e.g. 5xx)
-        if (response.status >= 500 && response.status < 600) {
-            const newServer = await PipingUtils.findWorkingPipingServer();
-            if (newServer) { // Check if a new server was actually found and is different
-                 const currentPipingDomain = PipingUtils.getCurrentDomain();
-                 this.sessionUrl = PipingUtils.getSessionUrl(this.pipeId, this.sessionId); // Rebuild URL with new domain
-                 this.showToast(`Reconnected to: ${currentPipingDomain.replace('https://', '').replace('/', '')}`);
-                 return false; // Indicate failure to trigger retry in triggerFetchLoop
-            }
-        }
+        // No server fallback, so just return false to retry after a delay
         return false;
       }
     } catch (error) {
       console.error('❌ Exception in mobile view fetchLoop:', error);
-      // This catch block might be hit for network errors or AbortError from timeout
-      // If it's a network error, try to find a new server.
-      if (error.name === 'TypeError' || error.message.includes('Failed to fetch')) { // Generic network error
-        const newServer = await PipingUtils.findWorkingPipingServer();
-        if (newServer) {
-            const currentPipingDomain = PipingUtils.getCurrentDomain();
-            this.sessionUrl = PipingUtils.getSessionUrl(this.pipeId, this.sessionId);
-            this.showToast(`Re-attempting connection via: ${currentPipingDomain.replace('https://', '').replace('/', '')}`);
-            return false; // Indicate failure to trigger retry
-        }
-      }
-      // For AbortError (timeout), typically we just want to try again without server change.
-      return false; // Indicate failure to trigger retry
+      // No server fallback, just return false to retry after a delay
+      return false;
     }
   }
 


### PR DESCRIPTION
…lusively uses `ppng.io`. Here are the changes I've made:

- In `js/piping-utils.js`, I've hardcoded `ppng.io` as the server and removed the functions for testing and falling back to other servers.
- I've updated `js/qr-deploy.js` and `view/mobile_view.js` to remove the calls to the server testing functions, which also simplified the error handling and retry logic.

This change makes the code simpler, but it also means we no longer have the backup of other servers.