### PR TITLE
fix: Force reload of 3D model in modal

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -185,6 +185,7 @@ if (galleryDisplay) {
     }
 
     if (modalViewer) {
+      modalViewer.src = '';
       modalViewer.cameraOrbit = '0deg 75deg 105%';
       modalViewer.setAttribute('src', modelUrl);
       modalViewer.setAttribute('alt', modelTitle);


### PR DESCRIPTION
This commit fixes a bug where the 3D model in the modal would become non-interactive after being closed and reopened.

The fix involves setting the `src` of the `<model-viewer>` to an empty string before setting it to the new model's URL. This forces the `<model-viewer>` to reload the model every time the modal is opened, ensuring that it is always interactive.