### PR TITLE
feat: Implement cache-based model loading

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -428,3 +428,7 @@ p {
 .model-card.loading model-viewer {
   animation: pulse 1.5s infinite;
 }
+
+.model-card.caching model-viewer {
+  animation: pulse 1.5s infinite;
+}

--- a/js/app.js
+++ b/js/app.js
@@ -136,36 +136,28 @@ if (galleryDisplay) {
       const modelUrl = modelCard.dataset.modelUrl;
       const cardModelViewer = modelCard.querySelector('model-viewer');
 
-      // If the model is already loaded, open the modal
-      if (modelCard.classList.contains('loaded')) {
+      // If the model is cached, open the modal
+      if (modelCard.classList.contains('cached')) {
         openModalWithModel(modelUrl, modelCard.dataset.title);
         return;
       }
 
-      // If the model is already loading, do nothing
-      if (modelCard.classList.contains('loading')) {
-        return;
-      }
-
-      // If another model is loading, cancel it
-      const currentlyLoading = document.querySelector('.model-card.loading');
-      if (currentlyLoading) {
-        currentlyLoading.classList.remove('loading');
-        const currentlyLoadingViewer = currentlyLoading.querySelector('model-viewer');
-        if (currentlyLoadingViewer) {
-          currentlyLoadingViewer.src = '';
-        }
-      }
-
-      // First click: start loading the model
-      modelCard.classList.add('loading');
-      if (cardModelViewer) {
-        cardModelViewer.src = modelUrl;
-        cardModelViewer.addEventListener('load', () => {
-          modelCard.classList.remove('loading');
-          modelCard.classList.add('loaded');
-        }, { once: true });
-      }
+      // First click: download and cache the model
+      modelCard.classList.add('caching');
+      caches.open('models-cache').then(cache => {
+        cache.match(modelUrl).then(response => {
+          if (!response) {
+            fetch(modelUrl).then(response => {
+              cache.put(modelUrl, response);
+              modelCard.classList.remove('caching');
+              modelCard.classList.add('cached');
+            });
+          } else {
+            modelCard.classList.remove('caching');
+            modelCard.classList.add('cached');
+          }
+        });
+      });
     }
   });
 
@@ -185,10 +177,19 @@ if (galleryDisplay) {
     }
 
     if (modalViewer) {
-      modalViewer.src = '';
-      modalViewer.cameraOrbit = '0deg 75deg 105%';
-      modalViewer.setAttribute('src', modelUrl);
-      modalViewer.setAttribute('alt', modelTitle);
+      caches.open('models-cache').then(cache => {
+        cache.match(modelUrl).then(response => {
+          if (response) {
+            response.blob().then(blob => {
+              const objectURL = URL.createObjectURL(blob);
+              modalViewer.src = '';
+              modalViewer.cameraOrbit = '0deg 75deg 105%';
+              modalViewer.setAttribute('src', objectURL);
+              modalViewer.setAttribute('alt', modelTitle);
+            });
+          }
+        });
+      });
     }
     if (overlay) {
       overlay.style.display = 'flex';


### PR DESCRIPTION
This commit introduces a new interaction model for loading and viewing 3D models in the gallery. The new interaction flow is as follows:

1.  The first click on a model tile downloads the model and stores it in the browser's cache.
2.  Subsequent clicks on the same model tile retrieve the model from the cache and load it into the modal.
3.  The model is reloaded every time the modal is opened to ensure interactivity.

This new interaction model improves your experience by reducing the number of downloads and by providing a more responsive feel.