### PR TITLE
feat: Add blurred glass effect to tile text

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -58,6 +58,7 @@ h1 {
   flex-shrink: 0; /* Prevent cards from shrinking */
   display: flex; /* To help with internal alignment if needed */
   flex-direction: column; /* Ensure content within card stacks vertically */
+  position: relative;
 }
 
 .model-card:hover {
@@ -78,14 +79,22 @@ model-viewer {
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: #fafafa; /* Default background */
+  background-color: transparent; /* Default background */
   --progress-bar-height: 5px;
   --progress-bar-color: #007bff; /* Blue color for the bar */
   --progress-mask: #efefef; /* Light grey for the track/background of the bar */
 }
 
 .model-info {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
   padding: 15px;
+  z-index: 1;
 }
 
 h2 {


### PR DESCRIPTION
This commit implements a blurred glass effect for the text background on the model gallery tiles.

To achieve this, the following changes were made to the CSS:
- The `model-viewer` element's background was set to transparent to allow the underlying poster image to be visible for the blur effect.
- The `.model-info` text container was positioned absolutely to overlay the model viewer.
- A `backdrop-filter: blur()` along with a semi-transparent background color was applied to the `.model-info` container to create the frosted glass look.