### PR TITLE
feat: Update gallery layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -16,7 +16,7 @@ h1 {
   display: grid;
   grid-template-rows: repeat(2, 1fr);
   grid-auto-flow: column;
-  grid-auto-columns: 140px;
+  grid-auto-columns: 280px;
   overflow-x: auto;
   overflow-y: hidden; /* Prevent vertical scrollbar on the gallery itself */
   gap: 20px; /* Maintains spacing between cards */
@@ -52,7 +52,7 @@ h1 {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   cursor: default; /* Change cursor as it's no longer a button for a modal */
   transition: transform 0.3s ease;
-  width: 140px; /* Fixed width for cards in the horizontal strip */
+  width: 280px; /* Fixed width for cards in the horizontal strip */
   display: flex; /* To help with internal alignment if needed */
   flex-direction: column; /* Ensure content within card stacks vertically */
 

--- a/models/models.js
+++ b/models/models.js
@@ -218,12 +218,6 @@ window.createModelCard = function(modelData, index) {
           shadow-intensity="1">
         </model-viewer>
       </div>
-      <div class="model-info">
-        <h2>${modelData.title}</h2>
-        <p>${modelData.description}</p>
-        <a href="${modelData.url}" download class="download-btn">Download</a>
-        <button class="expand-btn" data-index="${index}">Expand</button>
-      </div>
     </div>
   `;
   return cardHtml;


### PR DESCRIPTION
This commit introduces two changes to the gallery layout:

1.  The information banner at the bottom of each model tile has been removed to create a cleaner look.
2.  The size of the model tiles has been doubled, from 140x140 to 280x280, to make them more prominent.

These changes were made by:
- Removing the `.model-info` div from the `createModelCard` function in `models/models.js`.
- Updating the `grid-auto-columns` in `.gallery` and `width` in `.model-card` to `280px` in `css/styles.css`.