### PR TITLE
feat: Redesign gallery tiles with new layout and styling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -21,8 +21,8 @@ h1 {
   overflow-y: hidden; /* Prevent vertical scrollbar on the gallery itself */
   gap: 20px; /* Maintains spacing between cards */
   padding: 20px; /* Add some padding so cards don't touch edges */
-  /* max-width: 100%; /* Allow it to take full width for scrolling */
-  /* margin: 0 auto; /* Centering might not be desired for a full-width scroller */
+  max-width: 90vw; /* Allow it to take full width for scrolling */
+  margin: 0 auto; /* Centering might not be desired for a full-width scroller */
   -webkit-overflow-scrolling: touch; /* Smooth scrolling on iOS */
   scrollbar-width: thin; /* For Firefox */
   scrollbar-color: #ccc #f0f0f0; /* For Firefox */
@@ -55,7 +55,7 @@ h1 {
   width: 280px; /* Fixed width for cards in the horizontal strip */
   display: flex; /* To help with internal alignment if needed */
   flex-direction: column; /* Ensure content within card stacks vertically */
-
+  position: relative;
 }
 
 .model-card:hover {
@@ -81,7 +81,8 @@ model-viewer {
   --progress-mask: #efefef; /* Light grey for the track/background of the bar */
 }
 
-.model-info {
+/* New styles for title and download button */
+.model-title-container {
   position: absolute;
   bottom: 0;
   left: 0;
@@ -89,50 +90,40 @@ model-viewer {
   background-color: rgba(0, 0, 0, 0.25);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
-  padding: 15px;
+  padding: 10px;
   z-index: 1;
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
 }
 
-h2 {
-  margin-top: 0;
-  margin-bottom: 10px;
+.model-title-container h2 {
+  color: white;
+  font-size: 16px;
+  margin: 0;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
 }
 
-p {
-  color: #666;
-  margin: 0 0 15px 0;
-}
-
-/* Button styles */
 .download-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
   background-color: #4CAF50;
   color: white;
   border: none;
-  padding: 8px 12px;
-  border-radius: 4px;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
   cursor: pointer;
   text-decoration: none;
-  font-size: 14px;
-  display: inline-block;
+  font-size: 18px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1;
 }
 
 .download-btn:hover {
   background-color: #45a049;
-}
-
-.expand-btn {
-  background-color: #2196F3; /* Blue */
-  color: white;
-  border: none;
-  padding: 8px 12px;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 14px;
-  margin-left: 10px;
-}
-
-.expand-btn:hover {
-  background-color: #0b7dda;
 }
 
 /* Modal/Overlay styles */

--- a/models/models.js
+++ b/models/models.js
@@ -211,13 +211,17 @@ window.createModelCard = function(modelData, index) {
       <div class="model-container">
         <model-viewer
           src="${modelData.url}"
-          poster="data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%22300%22%20height%3D%22400%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20300%20400%22%20preserveAspectRatio%3D%22none%22%3E%3Cdefs%3E%3Cstyle%20type%3D%22text%2Fcss%22%3E%23holder_17ba8618998%20text%20%7B%20fill%3A%23999%3Bfont-weight%3Anormal%3Bfont-family%3AHelvetica%2C%20monospace%3Bfont-size%3A20pt%20%7D%20%3C%2Fstyle%3E%3C%2Fdefs%3E%3Cg%20id%3D%22holder_17ba8618998%22%3E%3Crect%20width%3D%22300%22%20height%3D%22400%22%20fill%3D%22%23eee%22%3E%3C%2Frect%3E%3Cg%3E%3Ctext%20x%3D%2296.3828125%22%20y%3D%22209.3609375%22%3ELoading...%3C%2Ftext%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E"
+          poster="${modelData.poster}"
 
           alt="${modelData.alt}"
           camera-controls
           shadow-intensity="1">
         </model-viewer>
       </div>
+      <div class="model-title-container">
+        <h2>${modelData.title}</h2>
+      </div>
+      <a href="${modelData.url}" download class="download-btn">⬇</a>
     </div>
   `;
   return cardHtml;


### PR DESCRIPTION
This commit implements a complete redesign of the gallery tiles based on your feedback.

The changes include:
- The model name is now positioned in the bottom-left corner of the tile with a 'glass effect' background for better readability.
- The download button has been moved to the top-right corner and is now a green, symbol-only button.
- The model description and the 'Expand' button have been removed to create a cleaner and more modern design.
- The tile's HTML structure in `models/models.js` has been updated to reflect the new layout.
- The CSS in `css/styles.css` has been updated to style the new layout, using absolute positioning for the new elements and removing unused styles.