### PR TITLE
Feat: Make model cards interactive and add expand button

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -115,6 +115,26 @@ p {
   background-color: #45a049;
 }
 
+.card-buttons {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.expand-btn {
+  background-color: #2196F3;
+  color: white;
+  border: none;
+  padding: 8px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.expand-btn:hover {
+  background-color: #0b7dda;
+}
+
 /* Modal/Overlay styles */
 .overlay {
   display: none;

--- a/js/app.js
+++ b/js/app.js
@@ -125,39 +125,15 @@ window.currentModelTitle = '';
 // Event delegation for dynamically generated model cards
 // Ensure galleryDisplay is not null before adding event listener
 if (galleryDisplay) {
+  // Handles clicks on the expand button to open the modal
   galleryDisplay.addEventListener('click', (event) => {
-    if (event.target.classList.contains('download-btn')) {
-      event.stopPropagation();
-      return;
-    }
-
-    const modelCard = event.target.closest('.model-card');
-    if (modelCard) {
-      const modelUrl = modelCard.dataset.modelUrl;
-      const cardModelViewer = modelCard.querySelector('model-viewer');
-
-      // If the model is cached, open the modal
-      if (modelCard.classList.contains('cached')) {
-        openModalWithModel(modelUrl, modelCard.dataset.title);
-        return;
+    if (event.target.classList.contains('expand-btn')) {
+      const modelCard = event.target.closest('.model-card');
+      if (modelCard) {
+        const modelUrl = modelCard.dataset.modelUrl;
+        const modelTitle = modelCard.dataset.title;
+        openModalWithModel(modelUrl, modelTitle);
       }
-
-      // First click: download and cache the model
-      modelCard.classList.add('caching');
-      caches.open('models-cache').then(cache => {
-        cache.match(modelUrl).then(response => {
-          if (!response) {
-            fetch(modelUrl).then(response => {
-              cache.put(modelUrl, response);
-              modelCard.classList.remove('caching');
-              modelCard.classList.add('cached');
-            });
-          } else {
-            modelCard.classList.remove('caching');
-            modelCard.classList.add('cached');
-          }
-        });
-      });
     }
   });
 
@@ -177,20 +153,27 @@ if (galleryDisplay) {
     }
 
     if (modalViewer) {
+      // The model might be in the browser's cache thanks to the interactive viewer
+      // Fetching it again to be sure and to place it in our specific cache if not already
       caches.open('models-cache').then(cache => {
-        cache.match(modelUrl).then(response => {
-          if (response) {
-            response.blob().then(blob => {
-              const objectURL = URL.createObjectURL(blob);
-              modalViewer.src = '';
-              modalViewer.cameraOrbit = '0deg 75deg 105%';
-              modalViewer.setAttribute('src', objectURL);
-              modalViewer.setAttribute('alt', modelTitle);
-            });
+        cache.match(modelUrl).then(cachedResponse => {
+          if (cachedResponse) {
+            return cachedResponse.blob();
           }
+          return fetch(modelUrl).then(networkResponse => {
+            cache.put(modelUrl, networkResponse.clone());
+            return networkResponse.blob();
+          });
+        }).then(blob => {
+          const objectURL = URL.createObjectURL(blob);
+          modalViewer.src = ''; // Clear previous model
+          modalViewer.cameraOrbit = '0deg 75deg 105%';
+          modalViewer.setAttribute('src', objectURL);
+          modalViewer.setAttribute('alt', modelTitle);
         });
       });
     }
+
     if (overlay) {
       overlay.style.display = 'flex';
       document.body.style.overflow = 'hidden';

--- a/models/models.js
+++ b/models/models.js
@@ -226,18 +226,23 @@ window.createModelCard = async function(modelData, index) {
       <div class="model-container">
         <model-viewer
           renderer-preference="${rendererPreference}"
-          data-src="${modelData.url}"
+          src="${modelData.url}"
           poster="${modelData.poster}"
           alt="${modelData.alt}"
           auto-rotate
           camera-controls
-          shadow-intensity="1">
+          shadow-intensity="1"
+          loading="lazy"
+          reveal="interaction">
         </model-viewer>
       </div>
       <div class="model-info">
         <h2>${modelData.title}</h2>
         <p>${modelData.description}</p>
-        <a href="${modelData.url}" download class="download-btn">Download</a>
+        <div class="card-buttons">
+          <button class="expand-btn">Expand</button>
+          <a href="${modelData.url}" download class="download-btn">Download</a>
+        </div>
       </div>
     </div>
   `;


### PR DESCRIPTION
Makes the model viewer on the main gallery page interactive and adds an "Expand" button to each card to open a larger modal view.

- Changes `<model-viewer>` to use the `src` attribute instead of `data-src` to enable direct interaction on the card.
- Adds `loading="lazy"` and `reveal="interaction"` for performance optimization.
- Adds an "Expand" button to each model card.
- Updates the gallery's click event listener in `js/app.js` to only trigger the modal on clicks from the "Expand" button.
- Adds CSS for the new button layout.