### PR TITLE
Feat: Implement random overlapping layout for gallery

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -440,16 +440,8 @@ h1 {
   animation: pulse 1.5s infinite;
 }
 
-/* New Fanned-Out Layout Styles */
-.model-card:nth-child(odd) {
-    transform: translateY(-15px) rotate(-2deg);
-}
-
-.model-card:nth-child(even) {
-    transform: translateY(15px) rotate(2deg);
-}
-
+/* Static layout styles are now handled by JavaScript */
 .model-card:hover {
-  transform: translateY(0) rotate(0) scale(1.05);
+  transform: translateY(-5px) scale(1.02);
   z-index: 10;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -283,4 +283,44 @@ function initializeDraggableWindow() {
     }
 }
 
-// Interactive Carousel Logic has been removed as per the new request for a static layout.
+// Random Layout Logic
+document.addEventListener('DOMContentLoaded', () => {
+    const gallery = document.querySelector('.gallery');
+    if (!gallery) return;
+
+    const cards = gallery.querySelectorAll('.model-card');
+    if (cards.length === 0) return;
+
+    cards.forEach((card, index) => {
+        // Don't apply margin to the first card
+        if (index > 0) {
+            const randomOverlap = 60 + Math.random() * 40; // Overlap between 60px and 100px (approx 20-30% of card width)
+            card.style.marginLeft = `-${randomOverlap}px`;
+        }
+
+        const randomRotation = (Math.random() - 0.5) * 10; // -5 to +5 degrees
+        const randomY = (Math.random() - 0.5) * 40; // -20 to +20 pixels
+
+        card.style.transform = `translateY(${randomY}px) rotate(${randomRotation}deg)`;
+
+        // Ensure cards layer on top of each other correctly
+        card.style.zIndex = index;
+    });
+
+    // Adjust hover effect to work with the new random layout
+    gallery.addEventListener('mouseover', (event) => {
+        const card = event.target.closest('.model-card');
+        if (card) {
+            // Bring hovered card to the front
+            card.style.zIndex = cards.length + 1;
+        }
+    });
+
+    gallery.addEventListener('mouseout', (event) => {
+        const card = event.target.closest('.model-card');
+        if (card) {
+            // Restore original z-index
+            card.style.zIndex = Array.from(cards).indexOf(card);
+        }
+    });
+});


### PR DESCRIPTION
This commit replaces the previous gallery layout with a new, static layout where cards are arranged in a random, overlapping pattern. This change was made to ensure all model cards are visible and accessible in a more artistic and dynamic way.

- The previous CSS for a fanned-out or carousel layout has been removed.
- A new JavaScript script has been added to `js/app.js`. On page load, this script applies unique, random inline styles (`transform` and `margin-left`) to each model card.
- The hover effect is updated via JavaScript to bring the active card to the front.
- The model loading strategy remains `reveal="interaction"`.
- All referenced poster images in the configuration have been confirmed to exist in the repository.