### PR TITLE
fix: Remove glow effect from gallery tiles

### DIFF
--- a/js/gallery-react.js
+++ b/js/gallery-react.js
@@ -33,7 +33,7 @@ function ModelCard({ model, style, onMouseEnter, onMouseLeave }) {
 
     const combinedStyle = {
         ...style,
-        boxShadow: edgeColor ? `inset 0 0 20px 5px ${edgeColor}` : '0 10px 30px rgba(0, 0, 0, 0.15)',
+        boxShadow: '0 10px 30px rgba(0, 0, 0, 0.15)',
     };
 
     const modelUrl = model.url.startsWith('http')


### PR DESCRIPTION
This commit removes the glow effect from the gallery tiles, as requested by the user. The `box-shadow` is now set to a standard shadow regardless of the poster's dominant color.