### PR TITLE
feat(desktop): Add in-browser video editing with ffmpeg.wasm

### DIFF
--- a/desktop/desktop.css
+++ b/desktop/desktop.css
@@ -7,3 +7,61 @@ body {
 canvas {
     display: block;
 }
+
+#video-controls {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    padding: 15px;
+    background-color: rgba(255, 255, 255, 0.85);
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.2);
+    z-index: 10;
+    width: 340px;
+}
+
+#video-controls h3 {
+    margin-top: 0;
+    margin-bottom: 10px;
+    font-family: sans-serif;
+    color: #333;
+}
+
+#video-controls input[type="file"] {
+    margin-bottom: 10px;
+    width: 100%;
+}
+
+#video-controls button {
+    padding: 8px 12px;
+    margin-right: 5px;
+    border: none;
+    border-radius: 4px;
+    background-color: #007bff;
+    color: white;
+    cursor: pointer;
+    font-size: 14px;
+}
+
+#video-controls button:hover {
+    background-color: #0056b3;
+}
+
+#video-controls #output-video {
+    width: 100%;
+    margin-top: 15px;
+    border-radius: 4px;
+    background-color: #000;
+}
+
+#video-controls #message {
+    margin-top: 10px;
+    font-family: monospace;
+    font-size: 12px;
+    color: #333;
+    height: 50px;
+    overflow-y: auto;
+    background: #eee;
+    padding: 5px;
+    border-radius: 3px;
+}

--- a/desktop/desktop.html
+++ b/desktop/desktop.html
@@ -4,12 +4,21 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>3D Desktop</title>
-    <style>
-        body { margin: 0; }
-        canvas { display: block; }
-    </style>
+    <link rel="stylesheet" href="desktop.css">
+    <script src="https://unpkg.com/@ffmpeg/ffmpeg@0.12.10/dist/umd/ffmpeg.js"></script>
+    <script src="https://unpkg.com/@ffmpeg/util@0.12.1/dist/umd/util.js"></script>
 </head>
 <body>
+    <div id="video-controls">
+        <h3>FFmpeg.wasm Video Editor</h3>
+        <input type="file" id="uploader" />
+        <br />
+        <button id="clip-button">Clip last 5 seconds</button>
+        <button id="resize-button">Resize to 360p</button>
+        <br />
+        <video id="output-video" controls muted></video>
+        <p id="message"></p>
+    </div>
     <script type="importmap">
         {
             "imports": {

--- a/desktop/desktop.js
+++ b/desktop/desktop.js
@@ -94,3 +94,101 @@ window.addEventListener('resize', () => {
     camera.updateProjectionMatrix();
     renderer.setSize(window.innerWidth, window.innerHeight);
 });
+
+// FFmpeg.wasm video processing logic
+const { FFmpeg } = window.FFmpeg;
+const { fetchFile, toBlobURL } = window.FFmpegUtil;
+
+const ffmpeg = new FFmpeg();
+
+const uploader = document.getElementById('uploader');
+const clipButton = document.getElementById('clip-button');
+const resizeButton = document.getElementById('resize-button');
+const video = document.getElementById('output-video');
+const message = document.getElementById('message');
+let inputFile = null;
+
+const load = async () => {
+    if (!ffmpeg.loaded) {
+        message.textContent = 'Loading ffmpeg-core.js...';
+        const baseURL = 'https://unpkg.com/@ffmpeg/core@0.12.6/dist/umd'
+        await ffmpeg.load({
+            coreURL: await toBlobURL(`${baseURL}/ffmpeg-core.js`, 'text/javascript'),
+            wasmURL: await toBlobURL(`${baseURL}/ffmpeg-core.wasm`, 'application/wasm'),
+        });
+        message.textContent = 'FFmpeg loaded. Please upload a video file.';
+        ffmpeg.on('log', ({ message: msg }) => {
+            const el = document.getElementById('message');
+            el.innerHTML = msg;
+            console.log(msg);
+        });
+        ffmpeg.on('progress', ({ progress, time }) => {
+            const el = document.getElementById('message');
+            if (progress < 1) {
+                el.innerHTML = `${Math.round(progress * 100)}% (transcoded time: ${time / 1000000}s)`;
+            }
+        });
+    }
+};
+
+const getDuration = (file) => {
+    return new Promise((resolve) => {
+        const tempVideo = document.createElement('video');
+        tempVideo.preload = 'metadata';
+        tempVideo.onloadedmetadata = () => {
+            window.URL.revokeObjectURL(tempVideo.src);
+            resolve(tempVideo.duration);
+        };
+        tempVideo.src = window.URL.createObjectURL(file);
+    });
+};
+
+const processVideo = async (args, outputFilename) => {
+    if (!inputFile) {
+        alert('Please upload a video file first.');
+        return;
+    }
+    await load();
+    message.textContent = 'Processing...';
+    const inputFilename = inputFile.name;
+    await ffmpeg.writeFile(inputFilename, await fetchFile(inputFile));
+
+    const command = ['-i', inputFilename, ...args, outputFilename];
+    await ffmpeg.exec(command);
+
+    const data = await ffmpeg.readFile(outputFilename);
+    video.src = URL.createObjectURL(new Blob([data.buffer], { type: 'video/mp4' }));
+    message.textContent = 'Processing complete.';
+    await ffmpeg.deleteFile(inputFilename);
+    await ffmpeg.deleteFile(outputFilename);
+};
+
+uploader.addEventListener('change', (e) => {
+    inputFile = e.target.files[0];
+    if (inputFile) {
+        message.textContent = `File "${inputFile.name}" selected.`;
+    }
+});
+
+clipButton.addEventListener('click', async () => {
+    if (!inputFile) {
+        alert('Please upload a video file first.');
+        return;
+    }
+    const duration = await getDuration(inputFile);
+    const startTime = Math.max(0, duration - 5);
+    const outputFilename = 'clipped.mp4';
+    const args = ['-ss', startTime.toString(), '-t', '5'];
+    await processVideo(args, outputFilename);
+});
+
+resizeButton.addEventListener('click', async () => {
+    const outputFilename = 'resized.mp4';
+    const args = ['-vf', 'scale=-1:360'];
+    await processVideo(args, outputFilename);
+});
+
+// Lazy load ffmpeg on first interaction
+uploader.addEventListener('focus', load, { once: true });
+clipButton.addEventListener('focus', load, { once: true });
+resizeButton.addEventListener('focus', load, { once: true });


### PR DESCRIPTION
This commit implements a new feature on the desktop page that allows users to upload a video file and perform basic editing operations (clipping and resizing) directly in the browser.

The implementation leverages `ffmpeg.wasm` to run FFmpeg commands in a web worker, processing the video on the client-side without needing a server.

Changes include:
- Modifying `desktop/desktop.html` to add UI controls for file upload, action buttons, and a video player for the output.
- Updating `desktop/desktop.css` to style the new UI elements, positioning them in an overlay on top of the 3D scene.
- Enhancing `desktop/desktop.js` with the logic to load `ffmpeg.wasm`, handle user interactions, and execute FFmpeg commands for clipping and resizing.