### PR TITLE
feat(desktop): Enable multi-threaded ffmpeg.wasm execution

### DIFF
--- a/desktop/desktop.css
+++ b/desktop/desktop.css
@@ -97,3 +97,13 @@ canvas {
 #video-controls button#apply-clip-button {
     margin-top: 10px;
 }
+
+.note {
+    font-size: 11px;
+    font-family: sans-serif;
+    color: #666;
+    background-color: #f0f0f0;
+    padding: 5px;
+    border-radius: 3px;
+    margin-top: 10px;
+}

--- a/desktop/desktop.html
+++ b/desktop/desktop.html
@@ -31,6 +31,9 @@
         <br />
         <video id="output-video" controls muted></video>
         <p id="message"></p>
+        <p class="note">
+            <strong>Note:</strong> Multi-threading requires the server to send specific headers (COOP and COEP). If it fails, it's likely due to server configuration.
+        </p>
     </div>
     <script type="importmap">
         {

--- a/desktop/desktop.js
+++ b/desktop/desktop.js
@@ -113,13 +113,14 @@ window.addEventListener('load', () => {
 
     const load = async () => {
         if (!ffmpeg.loaded) {
-            message.textContent = 'Loading ffmpeg-core.js...';
-            const baseURL = 'https://unpkg.com/@ffmpeg/core@0.12.6/dist/umd'
+            message.textContent = 'Loading ffmpeg-core.js (multi-threaded)...';
+            const baseURL = 'https://unpkg.com/@ffmpeg/core-mt@0.12.6/dist/umd'
             await ffmpeg.load({
                 coreURL: await toBlobURL(`${baseURL}/ffmpeg-core.js`, 'text/javascript'),
                 wasmURL: await toBlobURL(`${baseURL}/ffmpeg-core.wasm`, 'application/wasm'),
+                workerURL: await toBlobURL(`${baseURL}/ffmpeg-core.worker.js`, 'text/javascript'),
             });
-            message.textContent = 'FFmpeg loaded. Please upload a video file.';
+            message.textContent = 'FFmpeg (multi-threaded) loaded. Please upload a video file.';
             ffmpeg.on('log', ({ message: msg }) => {
                 const el = document.getElementById('message');
                 el.innerHTML = msg;


### PR DESCRIPTION
This commit updates the application to use the multi-threaded version of `ffmpeg.wasm` (`@ffmpeg/core-mt`) for potentially faster video processing.

Changes include:
- Modifying `desktop.js` to load the multi-threaded core and its required worker script.
- Adding a note to `desktop.html` and `desktop.css` to inform the user that this feature requires specific `COOP` and `COEP` server headers to be configured for `SharedArrayBuffer` to be available.