### PR TITLE
refactor(desktop): Revert to single-threaded ffmpeg.wasm

### DIFF
--- a/desktop/desktop.css
+++ b/desktop/desktop.css
@@ -97,13 +97,3 @@ canvas {
 #video-controls button#apply-clip-button {
     margin-top: 10px;
 }
-
-.note {
-    font-size: 11px;
-    font-family: sans-serif;
-    color: #666;
-    background-color: #f0f0f0;
-    padding: 5px;
-    border-radius: 3px;
-    margin-top: 10px;
-}

--- a/desktop/desktop.html
+++ b/desktop/desktop.html
@@ -31,9 +31,6 @@
         <br />
         <video id="output-video" controls muted></video>
         <p id="message"></p>
-        <p class="note">
-            <strong>Note:</strong> Multi-threading requires the server to send specific headers (COOP and COEP). If it fails, it's likely due to server configuration.
-        </p>
     </div>
     <script type="importmap">
         {

--- a/desktop/desktop.js
+++ b/desktop/desktop.js
@@ -120,14 +120,13 @@ window.addEventListener('load', () => {
 
     const load = async () => {
         if (!ffmpeg.loaded) {
-            message.textContent = 'Loading ffmpeg-core.js (multi-threaded)...';
-            const baseURL = 'https://unpkg.com/@ffmpeg/core-mt@0.12.6/dist/umd'
+            message.textContent = 'Loading ffmpeg-core.js...';
+            const baseURL = 'https://unpkg.com/@ffmpeg/core@0.12.6/dist/umd'
             await ffmpeg.load({
                 coreURL: await toBlobURL(`${baseURL}/ffmpeg-core.js`, 'text/javascript'),
                 wasmURL: await toBlobURL(`${baseURL}/ffmpeg-core.wasm`, 'application/wasm'),
-                workerURL: await toBlobURL(`${baseURL}/ffmpeg-core.worker.js`, 'text/javascript'),
             });
-            message.textContent = 'FFmpeg (multi-threaded) loaded. Please upload a video file.';
+            message.textContent = 'FFmpeg loaded. Please upload a video file.';
             ffmpeg.on('log', ({ message: msg }) => {
                 const el = document.getElementById('message');
                 el.innerHTML = msg;


### PR DESCRIPTION
This commit reverts the application from using the multi-threaded version of `ffmpeg.wasm` back to the standard single-threaded version, as requested.

This change simplifies the setup by removing the need for specific `COOP` and `COEP` server headers.

Changes include:
- Updating `desktop.js` to load the single-threaded `@ffmpeg/core` package and removing the `workerURL` configuration.
- Removing the UI note about server headers from `desktop.html` and its corresponding style from `desktop.css`.