### PR TITLE
fix(desktop): Add polling to fix race condition on ffmpeg load

### DIFF
--- a/desktop/desktop.js
+++ b/desktop/desktop.js
@@ -96,7 +96,7 @@ window.addEventListener('resize', () => {
 });
 
 // FFmpeg.wasm video processing logic
-window.addEventListener('load', () => {
+const initializeFFmpeg = () => {
     const { FFmpeg } = window.FFmpeg;
     const { fetchFile, toBlobURL } = window.FFmpegUtil;
 
@@ -216,8 +216,17 @@ window.addEventListener('load', () => {
         await processVideo(args, outputFilename);
     });
 
-
     // Lazy load ffmpeg on first interaction
     uploader.addEventListener('focus', load, { once: true });
     applyClipButton.addEventListener('focus', load, { once: true });
-});
+};
+
+const pollForFFmpeg = () => {
+    if (window.FFmpeg && window.FFmpegUtil) {
+        initializeFFmpeg();
+    } else {
+        setTimeout(pollForFFmpeg, 100);
+    }
+};
+
+pollForFFmpeg();


### PR DESCRIPTION
This commit fixes a persistent race condition where the FFmpeg logic in `desktop.js` would attempt to execute before the external `ffmpeg.js` UMD script had finished loading.

The previous fix using a `window.addEventListener('load', ...)` was insufficient. This commit replaces it with a more robust polling mechanism. The `pollForFFmpeg` function actively checks for the existence of `window.FFmpeg` and `window.FFmpegUtil` every 100ms and only initializes the main application logic once they are available. This ensures the libraries are ready before they are accessed.