### PR TITLE
fix: remove redundant gallery from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,63 +71,6 @@
   
   <h1>Space</h1>
   
-  
-  <div class="gallery">
-    <!-- Your original model -->
-    <div class="model-card" data-model="./models/31_10_2024.glb" data-title="My Model" data-desc="Original 3D model">
-      <div class="model-container">
-        <model-viewer
-          src="./models/31_10_2024.glb"
-          alt="Original 3D model"
-          auto-rotate
-          camera-controls
-          shadow-intensity="1">
-        </model-viewer>
-      </div>
-      <div class="model-info">
-        <h2>My Model</h2>
-        <p>Original 3D model</p>
-        <a href="./models/31_10_2024.glb" download class="download-btn">Download</a>
-      </div>
-    </div>
-    
-    <!-- Temple model -->
-    <div class="model-card" data-model="./models/20230204temple-transformed.glb" data-title="Temple" data-desc="Example 3D model">
-      <div class="model-container">
-        <model-viewer
-          src="./models/20230204temple-transformed.glb"
-          alt="Temple"
-          auto-rotate
-          camera-controls
-          shadow-intensity="1">
-        </model-viewer>
-      </div>
-      <div class="model-info">
-        <h2>Temple</h2>
-        <p>Example 3D model</p>
-        <a href="./models/20230204temple-transformed.glb" download class="download-btn">Download</a>
-      </div>
-    </div>
-    
-    <!-- Hibiscus model -->
-    <div class="model-card" data-model="./models/hibiscus.glb" data-title="Hibiscus" data-desc="Example 3D model">
-      <div class="model-container">
-        <model-viewer
-          src="./models/hibiscus.glb"
-          alt="hibiscus"
-          auto-rotate
-          camera-controls
-          shadow-intensity="1">
-        </model-viewer>
-      </div>
-      <div class="model-info">
-        <h2>Hibiscus</h2>
-        <p>Example 3D model</p>
-        <a href="./models/hibiscus.glb" download class="download-btn">Download</a>
-      </div>
-    </div>
-  </div>
-
   <div style="position: absolute; top: 10px; right: 10px;">
     <a href="cv/cv.html">CV</a>
     <a href="desktop/desktop.html" style="margin-left: 10px;">Desktop</a>


### PR DESCRIPTION
Removed the hardcoded gallery from index.html to resolve the issue of an empty card appearing. The gallery is now solely managed by the Vue.js application.