### PR TITLE
Feat: Add three-geo viewer page

### DIFF
--- a/geo-viewer/index.html
+++ b/geo-viewer/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<!--
+- `three-geo` is a three.js extension for 3D geographic visualization.
+- Copyright (c) 2016-2022, Wiaczeslaw Jakimowicz.
+-
+- `three-geo` is a free software: you can redistribute it and/or modify
+- it under the terms of the MIT License.
+-
+- This program is distributed in the hope that it will be useful,
+- but WITHOUT ANY WARRANTY; without even the implied warranty of
+- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+- MIT License for more details.
+-
+- You should have received a copy of the MIT License along with this
+- program. If not, see <https://opensource.org/licenses/MIT>.
+-->
+<html>
+<head>
+    <title>three-geo - geo-viewer</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="
+        default-src 'self';
+        script-src 'self' 'unsafe-inline' 'unsafe-eval' https://unpkg.com https://w3reality.github.io;
+        style-src 'self' 'unsafe-inline' https://w3reality.github.io;
+        connect-src 'self' https://w3reality.github.io;
+        img-src 'self' data: blob: https:;
+    ">
+    <link rel="stylesheet" type="text/css" href="https://w3reality.github.io/three-geo/examples/geo-viewer/io/main.css" />
+</head>
+<body>
+    <div id="root"></div>
+    <script>
+      window.THREE_GEO_SETTINGS = {
+        assets: 'https://w3reality.github.io/three-geo/assets',
+      };
+    </script>
+    <script src="https://unpkg.com/three@0.142.0/build/three.min.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="https://unpkg.com/three@0.142.0/examples/js/libs/dat.gui.min.js"></script>
+    <script src="https://w3reality.github.io/three-geo/dist/three-geo.min.js"></script>
+    <script src="https://w3reality.github.io/three-geo/examples/geo-viewer/io/main.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -76,6 +76,7 @@
     <a href="desktop/desktop.html" style="margin-left: 10px;">Desktop</a>
     <a href="projects.html" style="margin-left: 10px;">Projects</a>
     <a href="react-test/index.html" style="margin-left: 10px;">React Test</a>
+    <a href="geo-viewer/index.html" style="margin-left: 10px;">Geo Viewer</a>
   </div>
   <div class="title-container">
     <h1>Space</h1>


### PR DESCRIPTION
This commit introduces a new page that implements the `three-geo` geo-viewer example.

- A new directory `geo-viewer/` is created to house the new page.
- `geo-viewer/index.html` is added, containing the HTML and JavaScript from the example at `https://w3reality.github.io/three-geo/examples/geo-viewer/io/index.html`.
- The HTML is modified to use absolute URLs for all CSS and JS dependencies to ensure it works correctly within this project.
- A link to the new "Geo Viewer" page is added to the main navigation bar in `index.html`.